### PR TITLE
Fix typo in phpstan comment

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
     level: max
     excludePaths:
-        - src/tests/**/*.php # ignoring tests files because of Pest automagic injection of $this
+        - src/tests/**/*.php # ignoring test files because of Pest automagic injection of $this
         - **/config/*.php


### PR DESCRIPTION
## Summary
- fix typo in phpstan comment

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841b56efe40832f8f7a366667fa033f